### PR TITLE
Use the preload_parsed options to load the configuration

### DIFF
--- a/src/celery_yaml/loader.py
+++ b/src/celery_yaml/loader.py
@@ -10,29 +10,22 @@ import celery.loaders.base
 import yaml
 from celery import VERSION as celery_version  # type: ignore
 from celery import Celery
+from celery.signals import user_preload_options  # type: ignore
 
 log = logging.getLogger(__name__)
 
 
-if celery_version.major < 5:
+@user_preload_options.connect
+def on_preload_parsed(options: Mapping[str, Any], **kwargs: Any) -> None:
+    config_path = options["yaml"]
+    app = kwargs["app"]
 
-    from celery.signals import user_preload_options  # type: ignore
+    if config_path is None:
+        print("You must provide the --yaml argument")
+        sys.exit(-1)
 
-    @user_preload_options.connect
-    def on_preload_parsed(options: Mapping[str, Any], **kwargs: Any) -> None:
-        config_path = options["yaml"]
-        app = kwargs["app"]
-
-        if config_path is None:
-            print("You must provide the --yaml argument")
-            sys.exit(-1)
-
-        try:
-            loader = YamlLoader(app, config=config_path)
-            loader.read_configuration()
-        except Exception as err:
-            print(err)
-            sys.exit(-1)
+    loader = YamlLoader(app, config=config_path)
+    loader.read_configuration()
 
 
 def add_yaml_option(app: Celery) -> None:
@@ -47,23 +40,9 @@ def add_yaml_option(app: Celery) -> None:
 
     else:
 
-        from celery import bootsteps
         from click import Option
 
         app.user_options["preload"].add(Option(["--yaml"], required=True, help=help))
-
-        class YamlBootstep(bootsteps.Step):
-            def __init__(self, parent: Any, yaml: str = "", **options: Any) -> None:
-                try:
-                    loader = YamlLoader(app, config=yaml)
-                    loader.read_configuration()
-                    loader.import_default_modules()
-                except Exception as err:
-                    print(err)
-                    sys.exit(-1)
-                super().__init__(parent, **options)
-
-        app.steps["worker"].add(YamlBootstep)
 
 
 class YamlLoader(celery.loaders.base.BaseLoader):
@@ -90,9 +69,6 @@ class YamlLoader(celery.loaders.base.BaseLoader):
             self.app.config_from_object(_conf["celery"])
             if self.configure_logging and "logging" in _conf:
                 dictConfig(_conf["logging"])
-
-            # amqp is a cached_property that has to be refreshed
-            del self.app.amqp
 
             if hasattr(self.app, "on_yaml_loaded"):
                 getattr(self.app, "on_yaml_loaded")(_conf, config_path=self.config_path)


### PR DESCRIPTION
Remove the bootstep from celery 5, it is hackish for the use case and it does not work.

By the way the preload options is working with last version of celery 5 which was not the case on early version of celery 5
if my memory is fine (not sure).