### PR TITLE
Implement celery beat crontab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ select = [
     "UP",  # alter when better syntax is available
     "RUF", #  the ruff devleoper's own rules
 ]
+ignore = ["UP006", "UP035"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tests/config-celerybeat.yaml
+++ b/tests/config-celerybeat.yaml
@@ -1,0 +1,11 @@
+celery:
+  broker_url: amqp://guest:guest@rabbitmq:5672/
+  imports:
+    - "helloworld.tasks"
+  beat_schedule:
+    beat_it:
+      task: beat_it
+      schedule:
+        hour: 9
+        minute: 0
+        day_of_week: 1


### PR DESCRIPTION
Lest have some crontab support using a dict.

```yaml

celery:
  beat_schedule:
    beat_second:
      task: beat_it
      schedule: 10  # example of crontab

    beat_crontab:
      task: beat_it
      schedule:  # example of crontab
        hour: 9
        minute: 0
        day_of_week: 1


```