### PR TITLE
Log exceptions explicitly on startup

### DIFF
--- a/src/celery_yaml/loader.py
+++ b/src/celery_yaml/loader.py
@@ -28,8 +28,12 @@ def on_preload_parsed(options: Mapping[str, Any], **kwargs: Any) -> None:
         print("You must provide the --yaml argument")
         sys.exit(-1)
 
-    loader = YamlLoader(app, config=config_path, config_key=config_key)
-    loader.read_configuration()
+    try:
+        loader = YamlLoader(app, config=config_path, config_key=config_key)
+        loader.read_configuration()
+    except Exception:
+        log.exception("An error occured while loading YAML configuration")
+        raise  # Will be ignored by celery
 
 
 def add_yaml_option(app: Celery) -> None:


### PR DESCRIPTION
Since celery apparently does not show errors happening in the user_preload_options signal, errors happening here are not shown to the end user

Log the error explicitly to try to work around this